### PR TITLE
new feature: mergeDuplicates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+						<Main-Class>org.yaml.snakeyaml.Yaml2Yaml</Main-Class>
                         <_nouses>true</_nouses>
                         <Export-Package>
                             !org.yaml.snakeyaml.external*,

--- a/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
+++ b/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
@@ -23,6 +23,7 @@ public class LoaderOptions {
     private boolean allowRecursiveKeys = false;
     private boolean processComments = false;
     private boolean enumCaseSensitive = true;
+    private boolean mergeDuplicates = false;
 
     public boolean isAllowDuplicateKeys() {
         return allowDuplicateKeys;
@@ -45,6 +46,25 @@ public class LoaderOptions {
      */
     public void setAllowDuplicateKeys(boolean allowDuplicateKeys) {
         this.allowDuplicateKeys = allowDuplicateKeys;
+    }
+
+    public boolean mergeDuplicates() {
+        return mergeDuplicates;
+    }
+
+    /**
+     * If duplicated map keys are allowed, per default the previous value list
+     * of the duplicated key gets replaced by the value list of the new one.
+     * This is often unintentional and not what is needed. So if this option is
+     * set to {@code true}, the value list of the previous key gets prepend to
+     * the value list of the duplicate, and finally the previous key/value list
+     * deleted. This makes e.g. anchors/aliases much more useful as before.
+     *
+     * @param merge	If {@code true}, join the value lists of duplicated keys.
+     * 	Default is {@code false} to comply to YAML 1.2.
+     */
+    public void setMergeDuplicates(boolean merge) {
+        mergeDuplicates = merge;
     }
 
     public boolean isWrappedToRootException() {

--- a/src/main/java/org/yaml/snakeyaml/Yaml2Yaml.java
+++ b/src/main/java/org/yaml/snakeyaml/Yaml2Yaml.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2022, Jens Elkner (jel+snakeyaml@cs.uni-magdeburg.de).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml;
+
+import java.io.FileReader;
+import java.util.Map;
+
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
+/**
+ * Simple demo of the "merge duplicates" feature.
+ *
+ * @author Jens Elkner (jel+snakeyaml@cs.uni-magdeburg.de)
+ *
+ */
+public class Yaml2Yaml {
+	/**
+	 * Simple Application, which reads in a yaml document, merges the values of
+	 * duplicated keys and pretty prints the resulting document to stdout.
+	 * @param args the path to the yaml file to read.
+	 */
+	@SuppressWarnings("resource")
+	public static void main(String[] args) {
+		if (args.length == 0) {
+			System.err.println("Usage: java -jar snakeyaml.jar  file.yml");
+			System.exit(1);
+		}
+		LoaderOptions opts = new LoaderOptions();
+		opts.setAllowDuplicateKeys(true);
+		opts.setEnumCaseSensitive(true);
+		opts.setMergeDuplicates(true);
+		DumperOptions dopts = new DumperOptions();
+		dopts.setIndent(2);
+		dopts.setPrettyFlow(true);
+		dopts.setDefaultFlowStyle(FlowStyle.BLOCK);
+		dopts.setCanonical(false);
+		Yaml yaml= new Yaml(new SafeConstructor(opts), new Representer(dopts), dopts, opts);
+		FileReader fr = null;
+		try {
+			fr = new FileReader(args[0]);
+			@SuppressWarnings("unchecked")
+			Map<String,Object> map = (Map<String, Object>) yaml.load(fr);
+			System.out.print(yaml.dump(map));
+		} catch (Exception e) {
+			System.err.print(e.getLocalizedMessage());
+		} finally {
+			if (fr != null) {
+				try {
+					fr.close();
+				} catch (Exception e) {
+					System.err.print(e.getLocalizedMessage());
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
@@ -79,6 +79,7 @@ public abstract class BaseConstructor {
     private PropertyUtils propertyUtils;
     private boolean explicitPropertyUtils;
     private boolean allowDuplicateKeys = true;
+    private boolean mergeDuplicates = false;
     private boolean wrappedToRootException = false;
 
     private boolean enumCaseSensitive = false;
@@ -108,6 +109,7 @@ public abstract class BaseConstructor {
         typeDefinitions.put(SortedSet.class, new TypeDescription(SortedSet.class, Tag.SET,
                 TreeSet.class));
         this.loadingConfig = loadingConfig;
+        mergeDuplicates = loadingConfig.mergeDuplicates();
     }
 
     public void setComposer(Composer composer) {
@@ -594,6 +596,14 @@ public abstract class BaseConstructor {
 
     public void setAllowDuplicateKeys(boolean allowDuplicateKeys) {
         this.allowDuplicateKeys = allowDuplicateKeys;
+    }
+
+    public void setMergeDuplicates(boolean merge) {
+        mergeDuplicates = merge;
+    }
+
+    public boolean mergeDuplicates() {
+        return mergeDuplicates;
     }
 
     public boolean isWrappedToRootException() {


### PR DESCRIPTION
By using LoaderOptions().setMergeDuplicates(true) the values of
duplicated keys get merged into a single list keeping their order
and set to the last key found. All previous keys are removed so
that the resulting document is compatible with YAML 1.2 wrt. unique
keys (but nothing got lost ;-)).