### PR TITLE
Add JMH benchmarks for issue 1075

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,18 @@
             <version>1.18.24</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.36</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.36</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <distributionManagement>
         <repository>

--- a/src/test/java/org/yaml/snakeyaml/jmh/EmitterBenchmark.java
+++ b/src/test/java/org/yaml/snakeyaml/jmh/EmitterBenchmark.java
@@ -1,0 +1,96 @@
+package org.yaml.snakeyaml.jmh;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.emitter.Emitter;
+import org.yaml.snakeyaml.events.DocumentStartEvent;
+import org.yaml.snakeyaml.events.ImplicitTuple;
+import org.yaml.snakeyaml.events.ScalarEvent;
+import org.yaml.snakeyaml.events.SequenceStartEvent;
+import org.yaml.snakeyaml.events.StreamStartEvent;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Threads(8)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 3, time = 3)
+@State(Scope.Thread)
+public class EmitterBenchmark {
+
+  private Emitter emitter;
+
+  @Setup
+  public void setup(Blackhole blackhole) throws IOException {
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDefaultScalarStyle(DumperOptions.ScalarStyle.PLAIN);
+    emitter = new Emitter(new BlackholeWriter(blackhole), dumperOptions);
+    // Begin a sequence so that the benchmark may emit a scalar each iteration.
+    emitter.emit(new StreamStartEvent(null, null));
+    emitter.emit(new DocumentStartEvent(null, null, false, null, null));
+    emitter
+        .emit(new SequenceStartEvent(null, null, true, null, null, DumperOptions.FlowStyle.AUTO));
+  }
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Mode.AverageTime)
+  public void emitScalar() throws IOException {
+    emitter.emit(new ScalarEvent(null, null, new ImplicitTuple(true, false), "scalar", null, null,
+        DumperOptions.ScalarStyle.PLAIN));
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    new Runner(new OptionsBuilder().include(EmitterBenchmark.class.getSimpleName())
+        .addProfiler(GCProfiler.class).build()).run();
+  }
+
+  /**
+   * Writer implementation which sends input to the {@link Blackhole} to prevent dead code
+   * elimination.
+   */
+  private static final class BlackholeWriter extends Writer {
+    private final Blackhole blackhole;
+
+    BlackholeWriter(Blackhole blackhole) {
+      this.blackhole = blackhole;
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) {
+      blackhole.consume(cbuf);
+      blackhole.consume(off);
+      blackhole.consume(len);
+    }
+
+    @Override
+    public void write(String str, int off, int len) {
+      blackhole.consume(str);
+      blackhole.consume(off);
+      blackhole.consume(len);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
Before 26f5d5f8 (benchmarks run atop 98ff897):
```
Benchmark                                        Mode  Cnt     Score     Error   Units
EmitterBenchmark.emitScalar                      avgt    3     0.311 ±   0.009   us/op
EmitterBenchmark.emitScalar:·gc.alloc.rate       avgt    3  6697.479 ± 420.474  MB/sec
EmitterBenchmark.emitScalar:·gc.alloc.rate.norm  avgt    3   256.000 ±   0.001    B/op
EmitterBenchmark.emitScalar:·gc.count            avgt    3   108.000            counts
EmitterBenchmark.emitScalar:·gc.time             avgt    3    62.000                ms
```

After 26f5d5f8 (benchmarks run atop 8a3063b):
```
Benchmark                                        Mode  Cnt     Score     Error   Units
EmitterBenchmark.emitScalar                      avgt    3     0.220 ±   0.006   us/op
EmitterBenchmark.emitScalar:·gc.alloc.rate       avgt    3  4713.283 ± 303.238  MB/sec
EmitterBenchmark.emitScalar:·gc.alloc.rate.norm  avgt    3   128.000 ±   0.001    B/op
EmitterBenchmark.emitScalar:·gc.count            avgt    3   116.000            counts
EmitterBenchmark.emitScalar:·gc.time             avgt    3    63.000                ms
```

The benchmarks were run on a macbook, so cpu scaling makes the timing values a bit chaotic and I wouldn't put too much trust in the ~30% speedup shown. The important piece is `gc.alloc.rate.norm` which is the garbage collected bytes per `emitScalar` invocation, which cut in half.