### PR TITLE
Add missing 'exports org.yaml.snakeyaml.inspector' to module-info.java

### DIFF
--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -30,6 +30,7 @@ module org.yaml.snakeyaml {
     exports org.yaml.snakeyaml.error;
     exports org.yaml.snakeyaml.events;
     exports org.yaml.snakeyaml.extensions.compactnotation;
+    exports org.yaml.snakeyaml.inspector;
     exports org.yaml.snakeyaml.introspector;
     exports org.yaml.snakeyaml.nodes;
     exports org.yaml.snakeyaml.parser;


### PR DESCRIPTION
Otherwise nothing inside the `inspector` package can be used when `snakeyaml` is declared inside an external `module-info.java`.

![image](https://github.com/snakeyaml/snakeyaml/assets/66004280/77f5b5f2-cb14-4679-b0f9-83332731f7d2)
