### PR TITLE
Fixed flaky tests

### DIFF
--- a/src/test/java/org/yaml/snakeyaml/lowlevel/LowLevelApiTest.java
+++ b/src/test/java/org/yaml/snakeyaml/lowlevel/LowLevelApiTest.java
@@ -15,7 +15,7 @@ package org.yaml.snakeyaml.lowlevel;
 
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import junit.framework.TestCase;
@@ -30,7 +30,7 @@ public class LowLevelApiTest extends TestCase {
     List<Object> list = new ArrayList<Object>();
     list.add(1);
     list.add("abc");
-    Map<String, String> map = new HashMap<String, String>();
+    Map<String, String> map = new LinkedHashMap<String, String>();
     map.put("name", "Tolstoy");
     map.put("book", "War and People");
     list.add(map);

--- a/src/test/java/org/yaml/snakeyaml/types/BoolTagTest.java
+++ b/src/test/java/org/yaml/snakeyaml/types/BoolTagTest.java
@@ -14,6 +14,7 @@
 package org.yaml.snakeyaml.types;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
@@ -83,7 +84,7 @@ public class BoolTagTest extends AbstractTest {
    */
   public void testBoolOutAsEmpty2() {
     Yaml yaml = new Yaml(new BoolRepresenter("on"));
-    Map<String, Boolean> map = new HashMap<String, Boolean>();
+    Map<String, Boolean> map = new LinkedHashMap<String, Boolean>();
     map.put("aaa", false);
     map.put("bbb", true);
     String output = yaml.dump(map);
@@ -97,7 +98,7 @@ public class BoolTagTest extends AbstractTest {
     DumperOptions options = new DumperOptions();
     options.setDefaultFlowStyle(FlowStyle.BLOCK);
     Yaml yaml = new Yaml(new BoolRepresenter("True"), options);
-    Map<String, Boolean> map = new HashMap<String, Boolean>();
+    Map<String, Boolean> map = new LinkedHashMap<String, Boolean>();
     map.put("aaa", false);
     map.put("bbb", true);
     String output = yaml.dump(map);

--- a/src/test/java/org/yaml/snakeyaml/types/NullTagTest.java
+++ b/src/test/java/org/yaml/snakeyaml/types/NullTagTest.java
@@ -14,7 +14,7 @@
 package org.yaml.snakeyaml.types;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.yaml.snakeyaml.DumperOptions;
@@ -100,7 +100,7 @@ public class NullTagTest extends AbstractTest {
    */
   public void testNullOutAsEmpty2() {
     Yaml yaml = new Yaml(new NullRepresenter());
-    Map<String, String> map = new HashMap<String, String>();
+    Map<String, String> map = new LinkedHashMap<String, String>();
     map.put("aaa", "foo");
     map.put("bbb", null);
     String output = yaml.dump(map);
@@ -114,7 +114,7 @@ public class NullTagTest extends AbstractTest {
     DumperOptions options = new DumperOptions();
     options.setDefaultFlowStyle(FlowStyle.BLOCK);
     Yaml yaml = new Yaml(new NullRepresenter(), options);
-    Map<String, String> map = new HashMap<String, String>();
+    Map<String, String> map = new LinkedHashMap<String, String>();
     map.put("aaa", "foo");
     map.put("bbb", null);
     String output = yaml.dump(map);


### PR DESCRIPTION
Fixed the following flaky tests
1. org.yaml.snakeyaml.types.NullTagTest#testNullOutAsEmpty2
2. org.yaml.snakeyaml.types.NullTagTest#testBoolOutAsEmpty3
3. org.yaml.snakeyaml.lowlevel.LowLevelApiTest#testLowLevel
4. org.yaml.snakeyaml.types.BoolTagTest#testBoolOutAsEmpty3
5. org.yaml.snakeyaml.types.BoolTagTest#testBoolOutAsEmpty2

**Reproduce:**
The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=org.yaml.snakeyaml.types.NullTagTest#testNullOutAsEmpty2
```
The above command can be used as reference to reproduce flakiness for all the mentioned tests.

**Bug:**
Considering the test class ```NullTagTest``` and the test method ```testNullOutAsEmpty2``` , when we run the nonDex tool we get the following error log

> NullTagTest.testNullOutAsEmpty2:108 expected:<{[aaa: foo, bbb: !!null '']}  but was:<{[bbb: !!null '', aaa: foo]}

As we can see, the assertion in this test is failing because the order of elements differs. Same is the case for the other 4 tests mentioned above.

**Explanation:**
This change in order is cause by the use of ```HashMaps```. For the ```testNullOutAsEmpty2``` test method, we have the two lines

```
Map<String, String> map = new HashMap<String, String>();
String output = yaml.dump(map);
```
Here, ```yaml.dump()``` iterates through the map to create the string and as per the official [docs](https://docs.oracle.com/javase/6/docs/api/java/util/HashMap.html), order of returned items is not guaranteed for hashmaps. Hence, we encounter non-determinism while creating the string which causes the flakiness.

**Fix:**
To guarantee the order of items returned when iterating through the map, we can replace ```HashMap``` with ```LinkedHashMap```. For ```testNullOutAsEmpty2``` test method the change will be

```
Map<String, String> map = new LinkedHashMap<String, String>();
```
Same, change is proposed for the other flaky tests. After this change, the nonDex tool does not detect any flakiness.

**Test Environment:**

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic