### PR TITLE
Run snakeyaml without java.desktop module

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/introspector/MethodProperty.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/MethodProperty.java
@@ -13,11 +13,17 @@
  */
 package org.yaml.snakeyaml.introspector;
 
+import java.beans.FeatureDescriptor;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.util.ArrayUtils;
 
@@ -132,6 +138,42 @@ public class MethodProperty extends GenericProperty {
   @Override
   public boolean isReadable() {
     return readable;
+  }
+
+  private static final String TRANSIENT = "transient";
+
+  private static boolean isTransient(FeatureDescriptor fd) {
+    return Boolean.TRUE.equals(fd.getValue(TRANSIENT));
+  }
+
+  static void addProperties(Class<?> type, Map<String, Property> properties,
+      boolean[] inaccessableFieldsExist) {
+    try {
+      for (PropertyDescriptor property : Introspector.getBeanInfo(type).getPropertyDescriptors()) {
+        Method readMethod = property.getReadMethod();
+        if ((readMethod == null || !readMethod.getName().equals("getClass"))
+            && !isTransient(property)) {
+          properties.put(property.getName(), new MethodProperty(property));
+        }
+      }
+    } catch (IntrospectionException e) {
+      throw new YAMLException(e);
+    }
+
+    // add public fields
+    for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+      for (Field field : c.getDeclaredFields()) {
+        int modifiers = field.getModifiers();
+        if (!Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers)) {
+          if (Modifier.isPublic(modifiers)) {
+            properties.put(field.getName(), new FieldProperty(field));
+          } else {
+            inaccessableFieldsExist[0] = true;
+          }
+        }
+      }
+    }
+
   }
 
 }

--- a/src/main/java/org/yaml/snakeyaml/introspector/MethodProperty.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/MethodProperty.java
@@ -146,8 +146,15 @@ public class MethodProperty extends GenericProperty {
     return Boolean.TRUE.equals(fd.getValue(TRANSIENT));
   }
 
-  static void addProperties(Class<?> type, Map<String, Property> properties,
-      boolean[] inaccessableFieldsExist) {
+  /**
+   * Introspects given {@code type} and adds found properties to {@code properties} map.
+   *
+   * @param type the type to introspect
+   * @param properties map to add found properties to
+   * @return {@code true} if an inaccessible field was found
+   */
+  static boolean addPublicFields(Class<?> type, Map<String, Property> properties) {
+    boolean inaccessableFieldsExist = false;
     try {
       for (PropertyDescriptor property : Introspector.getBeanInfo(type).getPropertyDescriptors()) {
         Method readMethod = property.getReadMethod();
@@ -168,12 +175,12 @@ public class MethodProperty extends GenericProperty {
           if (Modifier.isPublic(modifiers)) {
             properties.put(field.getName(), new FieldProperty(field));
           } else {
-            inaccessableFieldsExist[0] = true;
+            inaccessableFieldsExist = true;
           }
         }
       }
     }
-
+    return inaccessableFieldsExist;
   }
 
 }

--- a/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
@@ -67,7 +67,7 @@ public class PropertyUtils {
     }
 
     Map<String, Property> properties = new LinkedHashMap<String, Property>();
-    boolean[] inaccessableFieldsExist = {false};
+    boolean inaccessableFieldsExist = false;
     if (bAccess == BeanAccess.FIELD) {
       for (Class<?> c = type; c != null; c = c.getSuperclass()) {
         for (Field field : c.getDeclaredFields()) {
@@ -79,9 +79,9 @@ public class PropertyUtils {
         }
       }
     } else {// add JavaBean properties
-      MethodProperty.addProperties(type, properties, inaccessableFieldsExist);
+      inaccessableFieldsExist = MethodProperty.addPublicFields(type, properties);
     }
-    if (properties.isEmpty() && inaccessableFieldsExist[0]) {
+    if (properties.isEmpty() && inaccessableFieldsExist) {
       throw new YAMLException("No JavaBean properties found in " + type.getName());
     }
     propertiesCache.put(type, properties);

--- a/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
@@ -42,21 +42,7 @@ public class PropertyUtils {
 
   PropertyUtils(PlatformFeatureDetector platformFeatureDetector) {
     this.platformFeatureDetector = platformFeatureDetector;
-
-    /*
-     * Android lacks much of java.beans (including the Introspector class, used here), because
-     * java.beans classes tend to rely on java.awt, which isn't supported in the Android SDK. That
-     * means we have to fall back on FIELD access only when SnakeYAML is running on the Android
-     * Runtime.
-     */
-    if (platformFeatureDetector.isRunningOnAndroid()) {
-      beanAccess = BeanAccess.FIELD;
-    }
-
-    /* when running with jlink restricted JDK without java.desktop package */
-    try {
-      Class.forName("java.beans.Introspector");
-    } catch (ClassNotFoundException ex) {
+    if (!platformFeatureDetector.isIntrospectionAvailable()) {
       beanAccess = BeanAccess.FIELD;
     }
   }

--- a/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
@@ -13,12 +13,7 @@
  */
 package org.yaml.snakeyaml.introspector;
 
-import java.beans.FeatureDescriptor;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.HashMap;
@@ -57,6 +52,13 @@ public class PropertyUtils {
     if (platformFeatureDetector.isRunningOnAndroid()) {
       beanAccess = BeanAccess.FIELD;
     }
+
+    /* when running with jlink restricted JDK without java.desktop package */
+    try {
+      Class.forName("java.beans.Introspector");
+    } catch (ClassNotFoundException ex) {
+      beanAccess = BeanAccess.FIELD;
+    }
   }
 
   protected Map<String, Property> getPropertiesMap(Class<?> type, BeanAccess bAccess) {
@@ -65,7 +67,7 @@ public class PropertyUtils {
     }
 
     Map<String, Property> properties = new LinkedHashMap<String, Property>();
-    boolean inaccessableFieldsExist = false;
+    boolean[] inaccessableFieldsExist = {false};
     if (bAccess == BeanAccess.FIELD) {
       for (Class<?> c = type; c != null; c = c.getSuperclass()) {
         for (Field field : c.getDeclaredFields()) {
@@ -77,44 +79,13 @@ public class PropertyUtils {
         }
       }
     } else {// add JavaBean properties
-      try {
-        for (PropertyDescriptor property : Introspector.getBeanInfo(type)
-            .getPropertyDescriptors()) {
-          Method readMethod = property.getReadMethod();
-          if ((readMethod == null || !readMethod.getName().equals("getClass"))
-              && !isTransient(property)) {
-            properties.put(property.getName(), new MethodProperty(property));
-          }
-        }
-      } catch (IntrospectionException e) {
-        throw new YAMLException(e);
-      }
-
-      // add public fields
-      for (Class<?> c = type; c != null; c = c.getSuperclass()) {
-        for (Field field : c.getDeclaredFields()) {
-          int modifiers = field.getModifiers();
-          if (!Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers)) {
-            if (Modifier.isPublic(modifiers)) {
-              properties.put(field.getName(), new FieldProperty(field));
-            } else {
-              inaccessableFieldsExist = true;
-            }
-          }
-        }
-      }
+      MethodProperty.addProperties(type, properties, inaccessableFieldsExist);
     }
-    if (properties.isEmpty() && inaccessableFieldsExist) {
+    if (properties.isEmpty() && inaccessableFieldsExist[0]) {
       throw new YAMLException("No JavaBean properties found in " + type.getName());
     }
     propertiesCache.put(type, properties);
     return properties;
-  }
-
-  private static final String TRANSIENT = "transient";
-
-  private boolean isTransient(FeatureDescriptor fd) {
-    return Boolean.TRUE.equals(fd.getValue(TRANSIENT));
   }
 
   public Set<Property> getProperties(Class<? extends Object> type) {

--- a/src/main/java/org/yaml/snakeyaml/util/PlatformFeatureDetector.java
+++ b/src/main/java/org/yaml/snakeyaml/util/PlatformFeatureDetector.java
@@ -17,6 +17,27 @@ public class PlatformFeatureDetector {
 
   private Boolean isRunningOnAndroid = null;
 
+  public boolean isIntrospectionAvailable() {
+    /*
+     * Android lacks much of java.beans (including the Introspector class, used here), because
+     * java.beans classes tend to rely on java.awt, which isn't supported in the Android SDK. That
+     * means we have to fall back on FIELD access only when SnakeYAML is running on the Android
+     * Runtime.
+     */
+    if (isRunningOnAndroid()) {
+      return false;
+    }
+
+    try {
+      Class.forName("java.beans.Introspector");
+      /* java.desktop module and its java.beans package is available */
+      return true;
+    } catch (ClassNotFoundException ex) {
+      /* running with jlink assembled JDK without java.desktop module */
+      return false;
+    }
+  }
+
   public boolean isRunningOnAndroid() {
     if (isRunningOnAndroid == null) {
       String name = System.getProperty("java.runtime.name");


### PR DESCRIPTION
I am experimenting with `jlink` trying to create a **small (headless) JDK** while still using `snakeyaml`. I created a small sample program in `Demo.java` file:
```java
import java.util.Map;
import org.yaml.snakeyaml.Yaml;

public class Demo {

    public static void main(String[] args) {
        Yaml yaml = new Yaml();
        String document = "hello: 25";
        Map map = (Map) yaml.load(document);
        Object h = map.get("hello");
        System.out.println("h: " + h);
    }
}
```
I compile it and run successfully with JDK21: 
```bash
$ jdk21/bin/javac -d . -cp snakeyaml-1.28.jar  Demo.java
$ jdk21/bin/java -cp .:snakeyaml-1.28.jar Demo
h: 25
```
however when I try to run it without `java.desktop` module, everything fails.

#### To reproduce

First of all let's build a small JDK via `jlink` command. I use:
```bash
$ jdk21/bin/jlink --output smalljdk --add-modules java.base
```
this generates a small, restricted JDK in `smalljdk` directory. Running with regular `snakeyaml-1.28` then fails with a **linkage error**:
```
$ smalljdk/bin/java -cp .:snakeyaml-1.28.jar Demo
Exception in thread "main" java.lang.NoClassDefFoundError: java/beans/IntrospectionException
        at org.yaml.snakeyaml.constructor.BaseConstructor.getPropertyUtils(BaseConstructor.java:559)
        at org.yaml.snakeyaml.constructor.BaseConstructor.addTypeDescription(BaseConstructor.java:579)
        at org.yaml.snakeyaml.constructor.Constructor.<init>(Constructor.java:103)
        at org.yaml.snakeyaml.constructor.Constructor.<init>(Constructor.java:80)
        at org.yaml.snakeyaml.constructor.Constructor.<init>(Constructor.java:62)
        at org.yaml.snakeyaml.constructor.Constructor.<init>(Constructor.java:48)
        at org.yaml.snakeyaml.Yaml.<init>(Yaml.java:66)
        at Demo.main(Demo.java:7)
Caused by: java.lang.ClassNotFoundException: java.beans.IntrospectionException
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
```
the problem is that `PropertyUtils` class is referencing `java.beans` classes (part of `java.desktop` JDK module) and those are not available. One of these classes is even in the signature of the `isTransient` method and thus the JDK verifier refuses to load the `PropertyUtils` class.

This PR fixes that by **restructuring the code**, so only `MethodProperty` class references the `java.beans` package. As this class isn't used in `BeanAccess.FIELD` mode, the following passes with the new `snakeyaml` JAR file:
```bash
snakeyaml$ smalljdk/bin/java -cp .:target/snakeyaml-2.3-SNAPSHOT.jar Demo
h: 25
```

These changes are not only useful for [our project](https://github.com/enso-org/enso), but for everyone trying to use snakeyaml on a headless JDK without `java.desktop`. Please consider accepting my refactoring.