### PR TITLE
Scanner#checkToken(Token.ID) avoids varargs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
         <project.scm.id>bitbucket</project.scm.id>
         <release.repo.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</release.repo.url>
         <snapshot.repo.url>https://oss.sonatype.org/content/repositories/snapshots/</snapshot.repo.url>
-        <maven.compiler.source>7</maven.compiler.source>
-        <maven.compiler.target>7</maven.compiler.target>
-        <maven.compiler.release>7</maven.compiler.release>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version><!-- for Github CI -->

--- a/src/main/java/org/yaml/snakeyaml/scanner/Scanner.java
+++ b/src/main/java/org/yaml/snakeyaml/scanner/Scanner.java
@@ -37,6 +37,18 @@ public interface Scanner {
   boolean checkToken(Token.ID... choices);
 
   /**
+   * Check if the next token is the given type.
+   *
+   * @param choice token ID to match with
+   * @return <code>true</code> if the next token is the given type. Returns <code>false</code> if no
+   *         more tokens are available.
+   * @throws ScannerException Thrown in case of malformed input.
+   */
+  default boolean checkToken(Token.ID choice) {
+    return checkToken(new Token.ID[] {choice});
+  }
+
+  /**
    * Return the next token, but do not delete it from the stream.
    *
    * @return The token that will be returned on the next call to {@link #getToken}

--- a/src/main/java/org/yaml/snakeyaml/scanner/ScannerImpl.java
+++ b/src/main/java/org/yaml/snakeyaml/scanner/ScannerImpl.java
@@ -231,8 +231,23 @@ public final class ScannerImpl implements Scanner {
   }
 
   /**
+   * Check whether the next token is the given type.
+   */
+  @Override
+  public boolean checkToken(Token.ID choice) {
+    while (needMoreTokens()) {
+      fetchMoreTokens();
+    }
+    if (!this.tokens.isEmpty()) {
+      return this.tokens.get(0).getTokenId() == choice;
+    }
+    return false;
+  }
+
+  /**
    * Check whether the next token is one of the given types.
    */
+  @Override
   public boolean checkToken(Token.ID... choices) {
     while (needMoreTokens()) {
       fetchMoreTokens();

--- a/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
+++ b/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.jmh;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.events.Event;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Fork(1)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 3, time = 10)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ParseBenchmark {
+
+  @Param({"1000", "100000"})
+  private int entries;
+  private String yamlString;
+  private final Yaml yaml = createYaml();
+
+  private static Yaml createYaml() {
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setCodePointLimit(Integer.MAX_VALUE);
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDefaultScalarStyle(DumperOptions.ScalarStyle.SINGLE_QUOTED);
+    return new Yaml(new Constructor(loaderOptions), new Representer(dumperOptions), dumperOptions);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    new Runner(new OptionsBuilder().include(ParseBenchmark.class.getSimpleName())
+            .build()).run();
+  }
+
+  @Setup
+  public void setup() throws IOException {
+    yamlString = yaml.dump(IntStream.range(0, entries).boxed()
+            .collect(Collectors.toMap(i -> i, i -> Integer.toString(i))));
+    System.out.printf("%nyaml bytes length: %d%n", yamlString.getBytes(StandardCharsets.UTF_8).length);
+  }
+
+  @Benchmark
+  public int parse(Blackhole bh) throws IOException {
+    int count = 0;
+    for (Event event : yaml.parse(new StringReader(yamlString))) {
+      bh.consume(event.getEventId());
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public Object load() throws IOException {
+    return yaml.load(yamlString);
+  }
+}


### PR DESCRIPTION
Calls to `Scanner#checkToken(Token.ID...)` with single arguments incur expensive varargs `Object[]` array allocations on very hot parsing code paths (e.g. `org.yaml.snakeyaml.parser.ParserImpl`). 

These can be avoided in JDK 8+ by adding a new `checkToken(Token.ID)` to the `Scanner` interface with default implementation, and overriding in `ScannerImpl` to provide a more efficient implementation.