### PR TITLE
Add JMH ParseBenchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ For YAML 1.2 (which is a superset of JSON) you may have a look at [SnakeYAML Eng
 * [Slack workspace](https://app.slack.com/client/T26CKL7FU/D02URJSL2KS)
 * Telegram group is removed because of the spam
 * [YAML community](https://matrix.to/#/%23chat:yaml.io)
+
+## JMH microbenchmarks ##
+
+To execute the [JMH](https://github.com/openjdk/jmh) microbenchmarks locally via Maven:
+
+```shell
+./mvnw jmh:benchmark
+```
+This will produce console results such as the following, as well as a `./jmh-result.json` that can be
+visualized via https://jmh.morethan.io/ .
+
+```text
+Benchmark                    (entries)  Mode  Cnt    Score     Error  Units
+EmitterBenchmark.emitScalar        N/A  avgt    3    0.299 ±   0.047  us/op
+ParseBenchmark.load               1000  avgt    3    1.388 ±   0.103  ms/op
+ParseBenchmark.load             100000  avgt    3  258.281 ± 367.009  ms/op
+ParseBenchmark.parse              1000  avgt    3    0.886 ±   0.163  ms/op
+ParseBenchmark.parse            100000  avgt    3   94.930 ±   3.995  ms/op
+```

--- a/pom.xml
+++ b/pom.xml
@@ -275,17 +275,9 @@
                 <groupId>pw.krejci</groupId>
                 <artifactId>jmh-maven-plugin</artifactId>
                 <version>0.2.2</version>
-                <executions>
-                    <execution>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>jmh</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <resultFormat>json</resultFormat>
-                    <resultFile>jmh-result.json</resultFile>
+                    <resultsFile>${project.build.directory}/jmh-result.json</resultsFile>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,23 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>pw.krejci</groupId>
+                <artifactId>jmh-maven-plugin</artifactId>
+                <version>0.2.2</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>jmh</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <resultFormat>json</resultFormat>
+                    <resultFile>jmh-result.json</resultFile>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
                 <version>1.10.b1</version>

--- a/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
+++ b/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.jmh;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.events.Event;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Fork(1)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 3, time = 10)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ParseBenchmark {
+
+  @Param({"1000", "100000"})
+  private int entries;
+  private String yamlString;
+  private final Yaml yaml = createYaml();
+
+  private static Yaml createYaml() {
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setCodePointLimit(Integer.MAX_VALUE);
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDefaultScalarStyle(DumperOptions.ScalarStyle.SINGLE_QUOTED);
+    return new Yaml(new Constructor(loaderOptions), new Representer(dumperOptions), dumperOptions);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    new Runner(new OptionsBuilder().include(ParseBenchmark.class.getSimpleName())
+            .build()).run();
+  }
+
+  @Setup
+  public void setup() throws IOException {
+    yamlString = yaml.dump(IntStream.range(0, entries).boxed()
+            .collect(Collectors.toMap(i -> i, i -> Integer.toString(i))));
+    System.out.printf("%nyaml bytes length: %d%n", yamlString.getBytes(StandardCharsets.UTF_8).length);
+  }
+
+  @Benchmark
+  public int parse(Blackhole bh) throws IOException {
+    int count = 0;
+    for (Event event : yaml.parse(new StringReader(yamlString))) {
+      bh.consume(event.getEventId());
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public Object load() throws IOException {
+    return yaml.load(yamlString);
+  }
+}

--- a/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
+++ b/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
@@ -38,10 +38,15 @@ import org.yaml.snakeyaml.representer.Representer;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
+/**
+ * JMH microbenchmark to test average processing time for relatively simple small (18.34 KiB for one
+ * thousand entries) and medium (2.17 MiB for one hundred thousand entries) yaml documents
+ * containing map of `entries`.
+ */
 @Fork(1)
 @Warmup(iterations = 3, time = 10)
 @Measurement(iterations = 3, time = 10)
@@ -64,15 +69,18 @@ public class ParseBenchmark {
   }
 
   public static void main(String[] args) throws RunnerException {
-    new Runner(new OptionsBuilder().include(ParseBenchmark.class.getSimpleName())
-            .build()).run();
+    new Runner(new OptionsBuilder().include(ParseBenchmark.class.getSimpleName()).build()).run();
   }
 
   @Setup
   public void setup() throws IOException {
-    yamlString = yaml.dump(IntStream.range(0, entries).boxed()
-            .collect(Collectors.toMap(i -> i, i -> Integer.toString(i))));
-    System.out.printf("%nyaml bytes length: %d%n", yamlString.getBytes(StandardCharsets.UTF_8).length);
+    Map<Integer, String> map = new HashMap<>(entries);
+    for (int i = 0; i < entries; i++) {
+      map.put(i, Integer.toString(i));
+    }
+    yamlString = yaml.dump(map);
+    System.out.printf("%nyaml bytes length: %d%n",
+        yamlString.getBytes(StandardCharsets.UTF_8).length);
   }
 
   @Benchmark


### PR DESCRIPTION
Split JMH `ParseBenchmark` out of #13 to provide a baseline for current parsing performance on small (18.34 KiB) and medium (2.17 MiB) sized yaml documents, and allow for comparisons for evaluating future improvements such as #13 and https://github.com/schlosna/snakeyaml/pull/1

Local baseline on `2021 Apple MacBookPro M1 Pro` with JDK 17 & JDK 21 runtimes

VM version: JDK 17.0.11, OpenJDK 64-Bit Server VM, 17.0.11+9-LTS

```
Benchmark             (entries)  Mode  Cnt    Score     Error  Units
ParseBenchmark.load        1000  avgt    3    1.605 ±   1.170  ms/op
ParseBenchmark.load      100000  avgt    3  247.998 ±  92.043  ms/op
ParseBenchmark.parse       1000  avgt    3    1.092 ±   0.296  ms/op
ParseBenchmark.parse     100000  avgt    3  114.479 ± 177.379  ms/op
```

VM version: JDK 21.0.3, OpenJDK 64-Bit Server VM, 21.0.3+9-LTS

```
Benchmark             (entries)  Mode  Cnt    Score    Error  Units
ParseBenchmark.load        1000  avgt    3    1.193 ±  0.063  ms/op
ParseBenchmark.load      100000  avgt    3  188.215 ± 13.995  ms/op
ParseBenchmark.parse       1000  avgt    3    0.895 ±  0.025  ms/op
ParseBenchmark.parse     100000  avgt    3   92.312 ±  9.998  ms/op
```