### PR TITLE
Reduce allocations and expensive operations parsing yaml

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
@@ -251,7 +251,7 @@ public class SafeConstructor extends BaseConstructor {
 
     @Override
     public Object construct(Node node) {
-      String value = constructScalar((ScalarNode) node).replaceAll("_", "");
+      String value = constructScalar((ScalarNode) node).replace("_", "");
       if (value.isEmpty()) {
         throw new ConstructorException("while constructing an int", node.getStartMark(),
             "found empty value", node.getStartMark());


### PR DESCRIPTION
`ParseBenchmark` shows between ~10% and ~20% speedup by removing allocations, GC overhead, and CPU work.

* `SafeConstructor#construct(Node)` uses `String#replace(String, String)` character replace to avoid expensive regex compilation and replacement when removing underscore character. This operation additionally may make use of vectorized `String#indexOf` on x64 & aarch64 to search for replacements.
* `ScannerImpl` `scanFlow*` methods append directly to existing `StringBuilder` instance to avoid allocating new `StringBuilder` and constructing intermediate `String`s.

Before
```
Benchmark             (entries)  Mode  Cnt    Score    Error  Units
ParseBenchmark.load        1000  avgt    3    1.235 ±  0.011  ms/op
ParseBenchmark.load      100000  avgt    3  177.019 ± 67.098  ms/op
ParseBenchmark.parse       1000  avgt    3    0.894 ±  0.009  ms/op
ParseBenchmark.parse     100000  avgt    3   92.165 ±  4.981  ms/op
```

After
```
Benchmark             (entries)  Mode  Cnt    Score    Error  Units
ParseBenchmark.load        1000  avgt    3    1.080 ±  0.084  ms/op
ParseBenchmark.load      100000  avgt    3  157.310 ±  7.027  ms/op
ParseBenchmark.parse       1000  avgt    3    0.706 ±  0.167  ms/op
ParseBenchmark.parse     100000  avgt    3   74.140 ± 15.403  ms/op
```