### PR TITLE
Add parameter free constructor, fix upgrade jar version startup failure

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/representer/Representer.java
+++ b/src/main/java/org/yaml/snakeyaml/representer/Representer.java
@@ -42,6 +42,14 @@ public class Representer extends SafeRepresenter {
 
   protected Map<Class<? extends Object>, TypeDescription> typeDefinitions = Collections.emptyMap();
 
+  /**
+   * Add parameter free constructor, fix upgrade jar version startup failure
+   */
+  public Representer() {
+    super(new DumperOptions());
+    this.representers.put(null, new RepresentJavaBean());
+  }
+
   public Representer(DumperOptions options) {
     super(options);
     this.representers.put(null, new RepresentJavaBean());


### PR DESCRIPTION
Upgrading snakeyaml from version 1. x to 2.2 will fail,
The classes in the snakeyaml project need to add non parametric constructs