### PR TITLE
Option to log duplicate keys #1101

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
+++ b/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
@@ -23,6 +23,8 @@ public class LoaderOptions {
 
   private boolean allowDuplicateKeys = true;
 
+  private boolean warnOnDuplicateKeys = true;
+
   private boolean wrappedToRootException = false;
 
   private int maxAliasesForCollections = 50; // to prevent YAML at
@@ -70,6 +72,35 @@ public class LoaderOptions {
    */
   public void setAllowDuplicateKeys(boolean allowDuplicateKeys) {
     this.allowDuplicateKeys = allowDuplicateKeys;
+  }
+
+  /**
+   * getter
+   *
+   * @return true when duplicate keys are logged as warning (the latter overrides the former)
+   */
+  public final boolean isWarnOnDuplicateKeys() {
+    return warnOnDuplicateKeys;
+  }
+
+  /**
+   * Log a warning for duplicate map keys in the YAML file.
+   *
+   * NOTE: this property will be processed only if allowDuplicateKeys is true.
+   *
+   * Default is false (no logging).
+   *
+   * YAML 1.1 is slightly vague around duplicate entries in the YAML file. The best reference is
+   * <a href="http://www.yaml.org/spec/1.1/#id862121"> 3.2.1.3. Nodes Comparison</a> where it hints
+   * that a duplicate map key is an error.
+   *
+   * For future reference, YAML spec 1.2 is clear. The keys MUST be unique.
+   * <a href="http://www.yaml.org/spec/1.2/spec.html#id2759572">1.3. Relation to JSON</a>
+   *
+   * @param warnOnDuplicateKeys true to log a warning on duplicate keys
+   */
+  public void setWarnOnDuplicateKeys(boolean warnOnDuplicateKeys) {
+    this.warnOnDuplicateKeys = warnOnDuplicateKeys;
   }
 
   /**

--- a/src/main/java/org/yaml/snakeyaml/Yaml.java
+++ b/src/main/java/org/yaml/snakeyaml/Yaml.java
@@ -216,6 +216,7 @@ public class Yaml {
     }
     this.constructor = constructor;
     this.constructor.setAllowDuplicateKeys(loadingConfig.isAllowDuplicateKeys());
+    this.constructor.setWarnOnDuplicateKeys(loadingConfig.isWarnOnDuplicateKeys());
     this.constructor.setWrappedToRootException(loadingConfig.isWrappedToRootException());
     if (!dumperOptions.getIndentWithIndicator()
         && dumperOptions.getIndent() <= dumperOptions.getIndicatorIndent()) {

--- a/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
@@ -91,6 +91,7 @@ public abstract class BaseConstructor {
   private PropertyUtils propertyUtils;
   private boolean explicitPropertyUtils;
   private boolean allowDuplicateKeys = true;
+  private boolean warnOnDuplicateKeys = false;
   private boolean wrappedToRootException = false;
 
   private boolean enumCaseSensitive = false;
@@ -670,6 +671,14 @@ public abstract class BaseConstructor {
 
   public void setAllowDuplicateKeys(boolean allowDuplicateKeys) {
     this.allowDuplicateKeys = allowDuplicateKeys;
+  }
+
+  public boolean isWarnOnDuplicateKeys() {
+    return warnOnDuplicateKeys;
+  }
+
+  public void setWarnOnDuplicateKeys(boolean warnOnDuplicateKeys) {
+    this.warnOnDuplicateKeys = warnOnDuplicateKeys;
   }
 
   public boolean isWrappedToRootException() {

--- a/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
@@ -19,6 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.internal.Logger;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.NodeId;
@@ -33,6 +34,8 @@ import org.yaml.snakeyaml.nodes.Tag;
 public class SafeConstructor extends BaseConstructor {
 
   public static final ConstructUndefined undefinedConstructor = new ConstructUndefined();
+
+  private Logger log = Logger.getLogger(this.getClass().getName());
 
   /**
    * Create an instance
@@ -114,6 +117,8 @@ public class SafeConstructor extends BaseConstructor {
           if (!isAllowDuplicateKeys()) {
             throw new DuplicateKeyException(node.getStartMark(), key,
                 tuple.getKeyNode().getStartMark());
+          } else if (isWarnOnDuplicateKeys() && log.isLoggable(Logger.Level.WARNING)) {
+            log.warn(String.format("duplicate keys found : %s", key));
           }
           toRemove.add(prevIndex);
         }

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1101/OptionToLogDuplicateKeysTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1101/OptionToLogDuplicateKeysTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.issues.issue1101;
+
+import org.junit.*;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Util;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.*;
+import java.util.logging.*;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * https://bitbucket.org/snakeyaml/snakeyaml/issues/1101
+ */
+public class OptionToLogDuplicateKeysTest {
+
+  private static final LogMessageInterceptorHandler LOG_MESSAGE_INTERCEPTOR_HANDLER =
+      new LogMessageInterceptorHandler();
+
+  /*
+   * Store the log level to restore at the end
+   */
+  private static Level PREVIOUS_LEVEL;
+
+  /*
+   * The logger to configure in order to intercept the log message
+   */
+  private static Logger logger = Logger.getLogger("org.yaml.snakeyaml.constructor");
+
+  /*
+   * Logging handler used to test if a message has been really logged.
+   */
+  public static class LogMessageInterceptorHandler extends Handler {
+
+    private Set<String> messages = new HashSet<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      // add log messages to a set
+      this.messages.add(record.getMessage());
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() throws SecurityException {
+
+    }
+
+    @Override
+    public boolean isLoggable(LogRecord record) {
+      return super.isLoggable(record);
+    }
+
+    public boolean containsLogMessage(String message) {
+      // check if a message has been logged
+      return this.messages.contains(message);
+    }
+
+  }
+
+  @BeforeClass
+  public static void start() {
+    // add log message intercepting handler
+    logger.addHandler(LOG_MESSAGE_INTERCEPTOR_HANDLER);
+    PREVIOUS_LEVEL = logger.getLevel();
+    logger.setLevel(Level.FINEST);
+  }
+
+  @AfterClass
+  public static void end() {
+    // restore the logger status
+    logger.removeHandler(LOG_MESSAGE_INTERCEPTOR_HANDLER);
+    logger.setLevel(PREVIOUS_LEVEL);
+  }
+
+  @Test
+  public void loadDuplicateKeys() {
+    InputStream str = Util.getInputstream("issues/issue1101-option-to-log-duplicate-keys.yaml");
+    LoaderOptions options = new LoaderOptions();
+    options.setWarnOnDuplicateKeys(true);
+    Yaml yaml = new Yaml(options);
+    Map<String, Object> sourceTree = yaml.load(str);
+    assertEquals(1, sourceTree.size());
+    // actual log message checking
+    Assert.assertTrue(
+        LOG_MESSAGE_INTERCEPTOR_HANDLER.containsLogMessage("duplicate keys found : banner"));
+  }
+
+}

--- a/src/test/resources/issues/issue1101-option-to-log-duplicate-keys.yaml
+++ b/src/test/resources/issues/issue1101-option-to-log-duplicate-keys.yaml
@@ -1,0 +1,6 @@
+---
+quarkus:
+  banner:
+    enabled: false
+  banner:
+    enabled: true


### PR DESCRIPTION
Hello, thanks for the great work on snakeyaml project.

I’ve been using either direcly on maby of the projects I work and indirecly (for instance smallrye-config).

In some of the teams I partecipate, sometimes some not very disciplined developer entered some duplicate keys in yaml configurations.

As far as I understand, right now SnakeYAML has an all or nothing approach to duplicate keys (using LoadOpttions.isAllowDuplicateKeys()): either an exception is thrown or they are totally ignored.

What about adding something like a isWarnOnDuplicateKeys() option to log duplicate keys?

https://bitbucket.org/snakeyaml/snakeyaml/issues/1101